### PR TITLE
changed uint32_t to unsigend int to compile for microblaze 32-bit arc…

### DIFF
--- a/src/src/commands/ush_cmd_xxd.c
+++ b/src/src/commands/ush_cmd_xxd.c
@@ -77,7 +77,7 @@ bool ush_buildin_cmd_xxd_service(struct ush_object *self, struct ush_file_descri
         case USH_STATE_PROCESS_SERVICE: {
                 switch (self->process_index) {
                 case 0:
-                        sprintf(self->desc->output_buffer, "%08X: ", (uint32_t)self->process_index_item);
+                        sprintf(self->desc->output_buffer, "%08X: ", (unsigned int)self->process_index_item);
                         ush_write_pointer(self, self->desc->output_buffer, self->state);
                         self->process_index = 1;
                         break;


### PR DESCRIPTION
* the microblaze 32-bit compiler interprets uint32_t as unsigned long which will lead to a compile error when using the format string %08X